### PR TITLE
Add network policy and update cronjob config

### DIFF
--- a/04-networkPolicy.yaml
+++ b/04-networkPolicy.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rclone-cronjob-network-policy
+  namespace: rclone-cronjob
+spec:
+  podSelector:
+    matchLabels:
+      app: rclone-cronjob
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress: [] # no ingress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except: # exclude nodes from the network
+        - 10.0.0.0/8 # local network
+        - 172.16.0.0/12 # local network
+        - 192.168.0.0/16 # local network
+    ports:
+    - protocol: TCP
+      port: 443 # HTTPS
+  - to: # allow DNS requests
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+        podSelector:
+          matchLabels:
+            k8s-app: kube-dns
+    ports:
+      - protocol: UDP
+        port: 53
+      - protocol: TCP
+        port: 53

--- a/05-cronjob.yaml
+++ b/05-cronjob.yaml
@@ -9,6 +9,10 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: rclone-cronjob
+            instance: rclone-cronjob
         spec:
           securityContext: 
             runAsNonRoot: true # Do not run as root
@@ -121,5 +125,5 @@ spec:
                   rclone ${RCLONE_OPTS} --log-level ${RCLONE_LOG_LEVEL} ${RCLONE_METHOD} \
                    :${SOURCE_TYPE},provider=${SOURCE_PROVIDER},access_key_id=${SOURCE_ACCESS_KEY},secret_access_key=${SOURCE_SECRET_KEY},endpoint=${SOURCE_ENDPOINT},bucket_acl=private:${SOURCE_BUCKET}/ \
                    :${DESTINATION_TYPE},provider=${DESTINATION_PROVIDER},access_key_id=${DESTINATION_ACCESS_KEY},secret_access_key=${DESTINATION_SECRET_KEY},endpoint=${DESTINATION_ENDPOINT},bucket_acl=private:${DESTINATION_BUCKET}/ 
-            imagePullPolicy: IfNotPresent
+            imagePullPolicy: Always
           restartPolicy: OnFailure

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A Kubernetes cronjob to sync two object stores using [rclone](http://rclone.org)
 
 ## How to use
 
+Ensure you are able to use [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) as this will simplify deployment.
+
 Update the `02-configmap.yaml` with your rclone config, for example:
 
 ```yaml
@@ -33,7 +35,7 @@ Update the `03-secrets.yaml` with your credentials:
   destination_secret_key: # replace with your destination secret key
 ```
 
-Then run `kubectl apply -f .`
+Then run `kubectl apply -k .`
 
 ### Notes
 

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - 01-namespace.yaml
+  - 02-configmap.yaml
+  - 03-secrets.yaml
+  - 04-networkPolicy.yaml
+  - 05-cronjob.yaml


### PR DESCRIPTION
- Introduced a new network policy for the cronjob.
- Renamed cronjob configuration file for clarity.
- Added labels to the cronjob template metadata.
- Changed image pull policy to always ensure latest image is used.
- Updated README to reflect kustomize usage instead of kubectl apply.
